### PR TITLE
멀티 모듈 DB 연동과 저장, 조회 로직 구현

### DIFF
--- a/src/main/java/dev/be/moduleapi/ModuleApiApplication.java
+++ b/src/main/java/dev/be/moduleapi/ModuleApiApplication.java
@@ -2,12 +2,15 @@ package dev.be.moduleapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(
         scanBasePackages = {"dev.be.moduleapi", "dev.be.modulecommon"}
 )
+@EntityScan("dev.be.modulecommon.domain")
+@EnableJpaRepositories(basePackages = "dev.be.modulecommon.repositories")
 public class ModuleApiApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(ModuleApiApplication.class, args);
     }

--- a/src/main/java/dev/be/moduleapi/controller/DemoController.java
+++ b/src/main/java/dev/be/moduleapi/controller/DemoController.java
@@ -13,7 +13,6 @@ public class DemoController {
 
     @GetMapping("/save")
     public String save() {
-        System.out.println(CodeEnum.SUCCESS.getCode());
         return demoService.save();
     }
 

--- a/src/main/java/dev/be/moduleapi/service/DemoService.java
+++ b/src/main/java/dev/be/moduleapi/service/DemoService.java
@@ -1,7 +1,9 @@
 package dev.be.moduleapi.service;
 
 import dev.be.moduleapi.exception.CustomException;
+import dev.be.modulecommon.domain.Member;
 import dev.be.modulecommon.enums.CodeEnum;
+import dev.be.modulecommon.repositories.MemberRepository;
 import dev.be.modulecommon.service.CommonDemoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,13 +12,19 @@ import org.springframework.stereotype.Service;
 @Service
 public class DemoService {
     private final CommonDemoService commonDemoService;
+
+    private final MemberRepository memberRepository;
     public String save() {
+        memberRepository.save(Member.builder()
+                .name("나다")
+                .build());
         System.out.println(CodeEnum.SUCCESS.getCode());
         System.out.println(commonDemoService.commonService());
         return "save";
     }
 
     public String find() {
+        System.out.println(memberRepository.findAll().size());
         return "find";
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/itservicedb
+    username: root
+    password: 102501
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  main:
+    allow-bean-definition-overriding: true
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate.ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        jdbc:
+          time_zone: Asia/Seoul
+
 


### PR DESCRIPTION
공통 모듈에서 MySQL, JPA 의존성을 추가해주고, Connection에 관련된 application 정보는 API 서버에 정의하여 DB를 연동했고,
공통 모듈에 정의한 Entity, Repository를 사용하기 위해 @EntityScan, @EnableJpaRepositories 어노테이션 추가해줌